### PR TITLE
Made the build/bootstrap scripts 'wrap' friendly and setup for drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,3 +1,3 @@
-image: rancher/docker-dind-base:latest
+image: rancher/docker-dind-base:v0.4.1
 script:
   - ./scripts/ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM rancher/docker-dind-base:v0.4.1
+COPY ./scripts/bootstrap /scripts/bootstrap
+RUN /scripts/bootstrap
+WORKDIR /source

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -7,7 +7,3 @@ apt-get install -y npm phantomjs
 update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10
 
 npm install -g bower ember-cli
-npm install
-bower --allow-root install
-git submodule init
-git submodule update

--- a/scripts/build
+++ b/scripts/build
@@ -3,4 +3,11 @@ set -e
 
 cd $(dirname $0)/..
 
+
+# Requires Access to the Source tree. Can not be used when building docker image. 302 wmaxwell
+npm install
+bower --allow-root install
+git submodule init
+git submodule update
+
 npm build

--- a/scripts/ci
+++ b/scripts/ci
@@ -3,6 +3,10 @@ set -e
 
 cd $(dirname $0)
 
+if [ "${ENABLE_DOCKER}" == "true" ]; then
+    wrapdocker
+fi
+
 ./clean
 ./bootstrap
 ./build


### PR DESCRIPTION
The bootstrap script doesn't depend on access to the source directory making it "wrap" script friendly. 

Locked to docker-dind-base v0.4.1 version in both CI and wrap Dockerfile. This forces consistency between the two environments likely to build.

fire off wrapdocker during ci so that containers can be brought in and run if needed.